### PR TITLE
Move page padding from layout to page sections

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
       <div className="wave"></div>
     </div>
     <Topbar data={{height: "3.5rem"}}/>
-    <main className="xl:px-80 px-4">{children}</main>
+    <main>{children}</main>
     </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,9 +13,13 @@ export default function Home() {
     <section>
       <RecoilRoot>
         <DescDataFetcher />
-        <GithubProfile />
-        <Projects />
-        <GithubRepos />
+        <section className="xl:px-80 px-4">
+          <GithubProfile />
+        </section>
+        <section className="xl:px-80 px-4 mt-8 lg:bg-transparent lg:border-0 bg-black border-t-2 border-neutral-800">
+          <Projects />
+          <GithubRepos />
+        </section>
       </RecoilRoot>
       <section className="lg:w-full h-fit flex items-center justify-center py-4 lg:mt-16 mt-4 gap-2 lg:text-xs text-xs text-neutral-500">
         <h1>Laboratory Website – @lif31up powered by 2025</h1>

--- a/component/feature/Github/GithubRepos.tsx
+++ b/component/feature/Github/GithubRepos.tsx
@@ -61,7 +61,7 @@ function RepoBlockRender({ data }: DefaultProps<RepoBlockDataType[]>) {
       <h1 className="lg:mx-2 w-fit mb-2 text-white font-bold lg:text-2xl text-xl">
         Repositories
       </h1>
-      <>{nodeListOfRepoBlock}</>
+      <section className="grid gap-2">{nodeListOfRepoBlock}</section>
     </section>
   );
 } // RepoBlockRender(Renderer)


### PR DESCRIPTION
Remove global padding from <main> in RootLayout and apply responsive padding to individual page sections. Wrap GithubProfile in its own padded section and group Projects + GithubRepos into a separate padded section with top margin and border/bg tweaks for visual separation. This gives finer control over spacing and styling of the profile and projects areas without relying on the global main wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined page layout structure with improved responsive spacing across desktop and mobile viewports.
  * Enhanced repository display with improved grid-based layout and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->